### PR TITLE
Changing gemspec to require newer version of winrm which addresses https:

### DIFF
--- a/em-winrm.gemspec
+++ b/em-winrm.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version	= '>= 1.9.1'
   s.add_dependency "eventmachine", "= 1.0.0.beta.3"
-  s.add_dependency "winrm", "= 1.0.1"
+  s.add_dependency "winrm", "~> 1.0.3"
   s.add_dependency "mixlib-log", ">= 1.3.0"
   s.add_dependency "uuidtools", "~> 2.1.1"
 


### PR DESCRIPTION
Changing gemspec to require newer version of winrm which addresses https://github.com/zenchild/WinRM/issues/11
