### PR TITLE
Basic Auth was always enabled

### DIFF
--- a/lib/em-winrm/server.rb
+++ b/lib/em-winrm/server.rb
@@ -33,7 +33,7 @@ module EventMachine
         @options[:user] = @options.delete(:user) || ENV['USER'] || ENV['USERNAME'] || "unknown"
         @options[:pass] = @options.delete(:password)
         @options[:port] = @options.delete(:port) || 5985
-        @options[:basic_auth_only] = @options.delete(:basic_auth_only) || true
+        @options[:basic_auth_only] = true unless defined? @options[:basic_auth_only]
       end
 
       #


### PR DESCRIPTION
@options[:basic_auth_only] = @options.delete(:basic_auth_only) || true will always evaluate to true.

Instead, I am only overwriting the value if it has not already been defined.
