### PR TITLE
KNIFE_WINDOWS-19 Pass through exit codes

### DIFF
--- a/lib/em-winrm/server.rb
+++ b/lib/em-winrm/server.rb
@@ -52,8 +52,8 @@ module EventMachine
             @shell.on_error do |error|
               @master.relay_error_from_backend(@host, error)
             end
-            @shell.on_close do |result|
-              @master.command_complete(@host, cid)
+            @shell.on_close do |result, exit_code|
+              @master.command_complete(@host, cid, exit_code)
             end
             @shell.run_command(data)
           end)

--- a/lib/em-winrm/shell.rb
+++ b/lib/em-winrm/shell.rb
@@ -65,6 +65,7 @@ module EventMachine
         end
         client.cleanup_command(@remote_id, command_id)
         WinRM::Log.debug("#{server.host}[#{@remote_id}] => :command_cleanup[#{command}]")
+        @last_exit_code = output[:exitcode]
         close
         output[:exitcode]
       end
@@ -75,7 +76,7 @@ module EventMachine
       def close
         r = client.close_shell(@remote_id)
         WinRM::Log.debug("#{server.host}[#{@remote_id}] => :shell_close")
-        @on_close.call(r) if @on_close
+        @on_close.call(r,@last_exit_code) if @on_close
       end
     end
   end


### PR DESCRIPTION
@schisamo This will allow knife or other calling processes to inspect the exit code for each server shell.
