### PR TITLE
Add no_ssl_peer_verification option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.gem
 .bundle
 Gemfile.lock
+.idea
 pkg/*

--- a/lib/em-winrm/server.rb
+++ b/lib/em-winrm/server.rb
@@ -34,6 +34,7 @@ module EventMachine
         @options[:pass] = @options.delete(:password)
         @options[:port] = @options.delete(:port) || 5985
         @options[:basic_auth_only] = true unless defined? @options[:basic_auth_only]
+        @options[:no_ssl_peer_verification] = false unless defined? @options[:no_ssl_peer_verification]
       end
 
       #

--- a/lib/em-winrm/version.rb
+++ b/lib/em-winrm/version.rb
@@ -18,7 +18,7 @@
 
 module EventMachine
   module WinRM
-    VERSION = "0.5.4.rc.1"
+    VERSION = "0.5.5"
     MAJOR, MINOR, TINY = VERSION.split('.')
   end
 end


### PR DESCRIPTION
This allows the user to disable ssl peer certificate verification, which is usefull when the target server uses WinRM with a self-signed cert, or a cert that doesn't match the server's hostname.

This commit works with commits to the WinRM (https://github.com/gswallow/WinRM/commit/f4ece4384df2768bc7756c3c5c336db65b05c674) and knife-windows (https://github.com/gswallow/knife-windows/commit/d04c835cfff1260017b91a799168e90b931cad6a) gems.