### PR TITLE
Allow later versions of eventmachine

### DIFF
--- a/em-winrm.gemspec
+++ b/em-winrm.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.description = s.summary
 
   s.required_ruby_version	= '>= 1.9.1'
-  s.add_dependency "eventmachine", "= 1.0.0.beta.3"
+  s.add_dependency "eventmachine", ">= 1.0.0.beta.3"
   s.add_dependency "winrm", "~> 1.1.0"
   s.add_dependency "mixlib-log", ">= 1.3.0"
   s.add_dependency "uuidtools", "~> 2.1.1"


### PR DESCRIPTION
This just bumps eventmachine from 1.0.0.beta.3 to that or anything later. This is necessary for some downstream projects. Not tested. See #6 for more details.
