### PR TITLE
Modified server.rb to include transport setting when determining URL pre...

### DIFF
--- a/lib/em-winrm/server.rb
+++ b/lib/em-winrm/server.rb
@@ -74,7 +74,7 @@ module EventMachine
 
       def client
         @winrm ||= begin
-          http_method = ( @options[:port].to_s=~/(443|5986)/ ? 'https' : 'http' )
+          http_method = ((@transport == :ssl) || @options[:port].to_s=~/(443|5986)/) ? 'https' : 'http' 
           endpoint = "#{http_method}://#{@host}:#{@options[:port]}/wsman"
           client = ::WinRM::WinRMWebService.new(endpoint, @transport, @options)
           client.set_timeout(@options[:operation_timeout]) if @options[:operation_timeout]


### PR DESCRIPTION
This is a fix for an issue I encountered while trying to bootstrap a Windows node that has an SSL listener that is not listening on a standard port like 5986 or 443.  In the current version of the code, when the port is not 443 or 5986 it will prefix the endpoint URL with http:// no matter what.  

The change I made will respect the --winrm-transport command line argument provided by the knife winrm plugin.  By specifying "-t ssl" or "--winrm-transport ssl", the endpoint URL will be prefixed with https://, regardless of the port specified.  If this argument is not specified, the code will fall back to the original method of using port number to determine the transport.