### PR TITLE
Loosen up the requirements for WinRM

### DIFF
--- a/em-winrm.gemspec
+++ b/em-winrm.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version	= '>= 1.9.1'
   s.add_dependency "eventmachine", "~> 1.0.0"
-  s.add_dependency "winrm", "~> 1.2.0"
+  s.add_dependency "winrm", "~> 1.2"
   s.add_dependency "mixlib-log", ">= 1.3.0"
   s.add_dependency "uuidtools", "~> 2.1.1"
 


### PR DESCRIPTION
These requirements are a bit tight and don't allow needed fixes to be used.  I loosened up WinRM, but probably all could be made less tight.